### PR TITLE
dj_local_conf.json file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+dj_local_conf.json

--- a/dj_local_conf.json
+++ b/dj_local_conf.json
@@ -1,6 +1,0 @@
-
-{
-    "database.host": "<database.host.name>",
-    "database.user": "<user>",
-    "database.password": "<password>"
-}


### PR DESCRIPTION
**What**:

I put the dj_local_conf.json in .gitignore

**Why**:

So we don't have to re-enter our database credentials after every push, at the same time we don't push them in our repos.